### PR TITLE
Fix post with body

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,9 @@ module.exports = function(input, init, tag) {
       xhr.setRequestHeader(name, value)
     })
 
-    xhr.send(typeof request._bodyInit === 'undefined' ? null : request._bodyInit)
+    var body = (init === null || typeof init.body === 'undefined') ? null : init.body;
+
+    xhr.send(body)
   })
 }
 


### PR DESCRIPTION
If you try do something like:

```
  const params = {
    method: 'POST',
    headers: new Headers({'Content-Type': 'application/json;charset=UTF-8'}),
    body: JSON.stringify({test: 'test'})
  };

  return (dispatch, getState) => fetch(URL, params, TAG_X);
```

The body is not sent in the request. 
Apparently, you hope that new Request() return an object with _bodyInit, but this don't happens. 

